### PR TITLE
Support for puppeteer-extra stealth plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This setting will change the default maximum navigation time.
 type:`Puppeteer`</br>
 default: `puppeteer`|`puppeteer-core`|`puppeteer-firefox`
 
-It's automatically detected based on your `dependencies` being supported [puppeteer](https://www.npmjs.com/package/puppeteer), [puppeteer-core](https://www.npmjs.com/package/puppeteer-core) or [puppeteer-firefox](https://www.npmjs.com/package/puppeteer-firefox).
+It's automatically detected based on your `dependencies` being supported [puppeteer](https://www.npmjs.com/package/puppeteer), [puppeteer-extra](https://www.npmjs.com/package/puppeteer-extra), [puppeteer-core](https://www.npmjs.com/package/puppeteer-core) or [puppeteer-firefox](https://www.npmjs.com/package/puppeteer-firefox).
 
 Alternatively, you can pass it.
 
@@ -114,6 +114,15 @@ default: `false`
 Every time a new page is created, it will be an incognito page.
 
 An incognito page will not share cookies/cache with other browser pages.
+
+##### stealthMode
+
+type:`boolean`</br>
+default: `false`
+
+Enables a bunch of evasion techniques that make the headless browser detection harder.
+
+Only works with the `puppeteer-extra` package and requires the [puppeteer-extra-plugin-stealth](https://www.npmjs.com/package/puppeteer-extra-plugin-stealth) to be installed
 
 ### .html(url, options)
 

--- a/packages/browserless/src/index.js
+++ b/packages/browserless/src/index.js
@@ -10,11 +10,14 @@ const EVALUATE_TEXT = page => page.evaluate(() => document.body.innerText)
 const EVALUATE_HTML = page => page.content()
 
 module.exports = ({
-  puppeteer = requireOneOf(['puppeteer', 'puppeteer-core', 'puppeteer-firefox']),
+  puppeteer = requireOneOf(['puppeteer-extra', 'puppeteer', 'puppeteer-core', 'puppeteer-firefox']),
   incognito = false,
   timeout = 30000,
   ...launchOpts
 } = {}) => {
+  if (launchOpts.stealthMode) {
+    puppeteer.use(require('puppeteer-extra-plugin-stealth')())
+  }
   let browser = puppeteer.launch({
     ignoreHTTPSErrors: true,
     args: [


### PR DESCRIPTION
The puppeteer-extra stealth plugin applies a bunch of evasion techniques to the underlying puppeteer instance, making it harder to detect the headless browser 
Addresses #11 