### PR TITLE
update adblocker + make use of puppeteer helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Dev Dependencies Status](https://img.shields.io/david/dev/Kikobeats/browserless.svg?style=flat-square)](https://david-dm.org/Kikobeats/browserless#info=devDependencies)
 [![NPM Status](https://img.shields.io/npm/dm/browserless.svg?style=flat-square)](https://www.npmjs.org/package/browserless)
 
-> A [puppeter](https://github.com/GoogleChrome/puppeteer)-like Node.js library for interacting with Headless production scenarios. 
+> A [puppeter](https://github.com/GoogleChrome/puppeteer)-like Node.js library for interacting with Headless production scenarios.
 
 ## Why
 
@@ -479,7 +479,7 @@ Internally the method performs a [.goto](#gotopage-options).
 
 ### .goto(page, options)
 
-It performs a smart [page.goto](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagegotourl-options), blocking [ads trackers](https://npm.im/is-tracking-domain)) requests and other requests based on `resourceType`.
+It performs a smart [page.goto](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagegotourl-options), blocking [ads and trackers](https://www.npmjs.com/package/@cliqz/adblocker) requests and other requests based on `resourceType`.
 
 ```js
 const browserless = require('browserless')

--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -29,12 +29,11 @@
   ],
   "dependencies": {
     "@browserless/devices": "^5.5.0",
-    "@cliqz/adblocker": "~0.10.0",
+    "@cliqz/adblocker": "~0.11.0",
     "debug": "~4.1.1",
     "got": "~9.6.0",
     "p-timeout": "~3.1.0",
-    "require-one-of": "~1.0.10",
-    "tldts": "~5.1.0"
+    "require-one-of": "~1.0.10"
   },
   "engines": {
     "node": ">= 8"

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -1,47 +1,14 @@
 'use strict'
 
-const { FiltersEngine, makeRequest } = require('@cliqz/adblocker')
+const { PuppeteerBlocker } = require('@cliqz/adblocker')
 const { getDevice } = require('@browserless/devices')
 const debug = require('debug')('browserless:goto')
-const tldts = require('tldts')
 const path = require('path')
 const fs = require('fs')
 
-const engine = FiltersEngine.parse(fs.readFileSync(path.resolve(__dirname, './rules.txt'), 'utf-8'))
+const engine = PuppeteerBlocker.deserialize(new Uint8Array(fs.readFileSync(path.resolve(__dirname, './engine.bin'))))
 
 const isEmpty = val => val == null || !(Object.keys(val) || val).length
-
-const types = {
-  document: 'main_frame',
-  eventsource: 'other',
-  fetch: 'xhr',
-  font: 'font',
-  image: 'image',
-  manifest: 'other',
-  media: 'media',
-  other: 'other',
-  script: 'script',
-  stylesheet: 'stylesheet',
-  texttrack: 'other',
-  websocket: 'websocket',
-  xhr: 'xhr'
-}
-
-/**
- *
- * Mapping from puppeteer request types to adblocker. This is needed because not all
- * types from puppeteer have the same name as the webRequest APIs from browsers
- * (which the adblocker expects).
- *
- * Related:
- * - https://github.com/GoogleChrome/puppeteer/blob/v1.14.0/docs/api.md#requestresourcetype
- * - https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType
- */
-const webRequestType = resourceType => {
-  const type = types[resourceType]
-  if (!type) throw Error(`Type ${resourceType} not mapped`)
-  return type
-}
 
 const WAIT_UNTIL = ['networkidle0']
 
@@ -62,40 +29,11 @@ module.exports = async (
   }
 ) => {
   await page.setRequestInterception(true)
-  let reqCount = { abort: 0, continue: 0 }
 
-  page.on('request', req => {
-    const resourceUrl = req.url()
-    const resourceType = req.resourceType()
-
-    if (abortTypes.includes(resourceType)) {
-      debug(`abort:${resourceType}:${++reqCount.abort}`, resourceUrl)
-      return req.abort()
-    }
-
-    if (adblock) {
-      const frame = req.frame()
-
-      const { match: isMatch } = engine.match(
-        makeRequest(
-          {
-            type: webRequestType(resourceType),
-            sourceUrl: frame ? frame.url() : undefined,
-            url: resourceUrl
-          },
-          url => tldts.parse(url)
-        )
-      )
-
-      if (isMatch) {
-        debug(`abort:tracker:${++reqCount.abort}`, resourceUrl)
-        return req.abort()
-      }
-    }
-
-    debug(`continue:${resourceType}:${++reqCount.continue}`, resourceUrl)
-    return req.continue()
-  })
+  if (adblock) {
+    debug('enable adblocker')
+    await engine.enableBlockingInPage(page)
+  }
 
   if (headers) {
     debug('set headers', headers)
@@ -128,6 +66,5 @@ module.exports = async (
     await page.waitFor(waitFor)
   }
 
-  debug(reqCount)
   return response
 }


### PR DESCRIPTION
Hi there,

We've published a new release of [@cliqz/adblocker](https://github.com/cliqz-oss/adblocker/releases/tag/v0.11.0). Among some small bug fixes, it contains a new blocker helper to ease the use of the library in the context of Puppeteer projects. I took the liberty of updating `browserless` with this change; let me know if this is acceptable or if you'd like me to make extra modifications. Alternatively, feel free to cherry-pick the commit; as I was not sure what the best way to make the PR was.

Here are a few improvements this PR would bring:

* Enabling adblocking for Puppeteer takes only one line now and there is not need to deal with requests explicitly (the use of `tldts` for parsing has also be internalized): `await engine.enableBlockingInPage(page);`
* More ads are now blocked (you get the same full-blown experience as with a WebExtension in the browser). This is the results of a few extra capabilities added in the context of Puppeteer:
  - requests can be redirected to data URLs (e.g.: google analytics would not be blocked, but instead a fake response would be injected so that the site does not break, but there is no tracking and no performance cost since the real request did not happen)
  - full cosmetic filtering is applied; which means that more ads will be blocked (in fact some of them might now be hidden whereas it was not possible before with only network filtering). Check Google ads for example (well in fact you should not see them anymore...). This feature should also reduce the likelihood of breakage as well as defuse "paywalls" (where a site asks you to disable the adblocker to proceed = no more!).
* I changed `postinstall.js` from `goto` package so that the full adblocker is created and dumped on disk in its binary form at install time. Initializing `PuppeteerBlocker` from this binary blob is *extremely* fast (i.e.: at least 3 orders of magnitude faster than parsing the lists from scratch, we're talking about less than 10ms on cold start). Since `postinstall.js` is done once, but `goto(...)` can be called lots of times, this means that warm-up time will be drastically reduced when using `goto`.
* Removed this particular list `'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/recipes/recipes_en.txt'` which is not supported. There should be no visible difference in terms of blocking.

Caveat: the debug logs for adblocker have been removed as there is currently no way to know which requests where blocked (everything happens internally in `PuppeteerBlocker`). If that is a desired capability, we could easily add a hook/callback to get some statistics about blocked requests.

Best,
Rémi
