### PR TITLE
build: only use compatible rules

### DIFF
--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@browserless/devices": "^5.5.5",
     "@cliqz/adblocker": "~0.11.0",
-    "binary-split": "~1.0.5",
     "debug": "~4.1.1",
     "debug-logfmt": "~1.0.2",
     "got": "~9.6.0",


### PR DESCRIPTION
After using https://github.com/StevenBlack/hosts on production scenarios, I noted it makes the execution slow.

I'm not sure if this is happening based on the number of rules or because I'm doing an adaptation from the original rule definition.

