### PR TITLE
chore: update @cliqz/adblocker-puppeteer to latest

### DIFF
--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@browserless/devices": "^5.5.5",
-    "@cliqz/adblocker": "~0.11.0",
+    "@cliqz/adblocker-puppeteer": "~0.12.0",
     "debug": "~4.1.1",
     "debug-logfmt": "~1.0.2",
     "got": "~9.6.0",

--- a/packages/goto/scripts/postinstall.js
+++ b/packages/goto/scripts/postinstall.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { PuppeteerBlocker, getLinesWithFilters } = require('@cliqz/adblocker')
+const { PuppeteerBlocker, getLinesWithFilters } = require('@cliqz/adblocker-puppeteer')
 const debug = require('debug-logfmt')('browserless:goto:postinstall')
 const { promisify } = require('util')
 const crypto = require('crypto')
@@ -49,10 +49,7 @@ const fetchFilterList = async url => {
 
 const fetchLists = async (urls, fn) => {
   const filterLists = await Promise.all(urls.map(fn))
-  const set = filterLists.reduce(
-    (acc, set) => new Set([...acc, ...set]),
-    new Set()
-  )
+  const set = filterLists.reduce((acc, set) => new Set([...acc, ...set]), new Set())
   debug('filters', { urls: urls.length, count: set.size })
   return Array.from(set)
 }

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const debug = require('debug-logfmt')('browserless:goto')
-const { PuppeteerBlocker } = require('@cliqz/adblocker')
+const { PuppeteerBlocker } = require('@cliqz/adblocker-puppeteer')
 const { getDevice } = require('@browserless/devices')
 const path = require('path')
 const fs = require('fs')


### PR DESCRIPTION
We now make use of @cliqz/adblocker-puppeteer instead of @cliqz/adblocker, it re-exposes the same symbols as the later, with extra abstraction for puppeteer integration.

Supersedes https://github.com/Kikobeats/browserless/pull/55