### PR TITLE
chore: update @cliqz/adblocker-puppeteer to latest

### DIFF
--- a/packages/goto/package.json
+++ b/packages/goto/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@browserless/devices": "^5.5.5",
-    "@cliqz/adblocker-puppeteer": "~0.12.0",
+    "@cliqz/adblocker-puppeteer": "~0.13.2",
     "debug": "~4.1.1",
     "debug-logfmt": "~1.0.2",
     "got": "~9.6.0",

--- a/packages/goto/scripts/postinstall.js
+++ b/packages/goto/scripts/postinstall.js
@@ -1,76 +1,28 @@
 'use strict'
 
-const { PuppeteerBlocker, getLinesWithFilters } = require('@cliqz/adblocker-puppeteer')
-const debug = require('debug-logfmt')('browserless:goto:postinstall')
+const { PuppeteerBlocker, fullLists } = require('@cliqz/adblocker-puppeteer')
 const { promisify } = require('util')
-const crypto = require('crypto')
-const { EOL } = require('os')
 const got = require('got')
 const fs = require('fs')
 
 const writeFile = promisify(fs.writeFile)
 
-// uBlock Origin –  https://github.com/uBlockOrigin/uAssets/tree/master/filters
-const RESOURCES =
-  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resources.txt'
-
-const FILTERS = [
-  // uBlock Origin –  https://github.com/uBlockOrigin/uAssets/tree/master/filters
-  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt',
-  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances.txt',
-  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt',
-  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/privacy.txt',
-  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt',
-  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt',
-
-  // Fanboy – https://www.fanboy.co.nz
-  // Easylist, Easyprivacy, Enhanced Trackers
-  'https://www.fanboy.co.nz/r/fanboy-complete.txt',
-  // Fanboy Annoyances List + Fanboy-Social List
-  'https://easylist-downloads.adblockplus.org/fanboy-annoyance.txt',
-  // Other
-  // Cookies Lists
-  'https://www.fanboy.co.nz/fanboy-cookiemonster.txt',
-  // crypto miners
-  'https://raw.githubusercontent.com/hoshsadiq/adblock-nocoin-list/master/nocoin.txt',
-  'http://pgl.yoyo.org/as/serverlist.php?hostformat=adblockplus;showintro=0&mimetype=plaintext'
-]
-
 const OUTPUT_FILENAME = 'src/engine.bin'
 
-const fetch = async url => (await got(url)).body
+// Lightweight `fetch` polyfill on top of `got` to allow consumption by adblocker
+const fetch = async url => {
+  const body = (await got(url)).body
 
-const fetchFilterList = async url => {
-  const entries = await fetch(url)
-  const filters = getLinesWithFilters(entries)
-  debug('filters', { url, count: filters.size })
-  return filters
-}
-
-const fetchLists = async (urls, fn) => {
-  const filterLists = await Promise.all(urls.map(fn))
-  const set = filterLists.reduce((acc, set) => new Set([...acc, ...set]), new Set())
-  debug('filters', { urls: urls.length, count: set.size })
-  return Array.from(set)
+  return {
+    text: () => body,
+    arrayBuffer: () => Buffer.from(body, 'ascii').buffer,
+    json: () => JSON.parse(body)
+  }
 }
 
 const main = async () => {
-  // fetch all rules and merge it into an unique list of rules
-  const rules = await fetchLists(FILTERS, fetchFilterList)
-
-  debug.info('total', { count: rules.length })
-
   // create a ad-blocker engine
-  const engine = PuppeteerBlocker.parse(rules.join(EOL))
-
-  // save the engine to be used lately by the process
-  const resources = await fetch(RESOURCES)
-  const checksum = crypto
-    .createHash('sha1')
-    .update(resources, 'utf8')
-    .digest('hex')
-
-  engine.updateResources(resources, checksum)
+  const engine = await PuppeteerBlocker.fromLists(fetch, fullLists)
   await writeFile(OUTPUT_FILENAME, engine.serialize())
 }
 

--- a/packages/goto/src/index.js
+++ b/packages/goto/src/index.js
@@ -32,6 +32,14 @@ module.exports = async (
   if (adblock) {
     debug('enable adblocker')
     await engine.enableBlockingInPage(page)
+
+    engine.on('request-blocked', ({ url }) => {
+      debug('request blocked', url)
+    })
+
+    engine.on('request-redirected', ({ url }) => {
+      debug('request redirected', url)
+    })
   }
 
   if (headers) {


### PR DESCRIPTION
Hi there,

In this PR I update `@cliqz/adblocker-puppeteer` to latest version (`v0.13.1`) which allows to reduce the complexity of integration in `browserless`. In particular now initialization and fetching lists are taken care of by `PuppeteerBlocker` directly, and there are events we can listen to, which allows to emit debug logs and ensure everything is working properly.

The `fullLists` exported from the library is an array of URLs, equivalent to the lists you currently use. It allows to perform: adblocking, tracking blocking and annoyance removal. The fact that it's now part of the upstream library will allow me to make sure it works well with the library, both in terms of performance and breakage; one less worry for you! Also, in the future I can make sure it evolve and stay optimal to deliver the best experience.

Best,
Rémi